### PR TITLE
refactor(ui): refactor gallery screens for unified pagination and error handling

### DIFF
--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/components/ListComponents.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/components/ListComponents.kt
@@ -38,7 +38,8 @@ fun LoadingFooter(
  */
 @Composable
 fun EndOfListFooter(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    message: String,
 ) {
     Box(
         modifier = modifier
@@ -47,7 +48,7 @@ fun EndOfListFooter(
         contentAlignment = Alignment.Center
     ) {
         Text(
-            text = "No more data",
+            text = message,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.secondary
         )

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/extensions/LazyListExtensions.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/extensions/LazyListExtensions.kt
@@ -30,6 +30,7 @@ import io.lackstudio.omnihub.compose.ui.components.LoadingFooter
 inline fun <T> LazyListScope.pagingItems(
     items: List<T>,
     isEndOfList: Boolean,
+    appendError: String?,
     prefetchDistance: Int = 3, // Default triggers when the 3rd from last item is reached
     noinline onLoadMore: () -> Unit,
     noinline key: ((item: T) -> Any)? = null,
@@ -53,10 +54,14 @@ inline fun <T> LazyListScope.pagingItems(
 
     // Render bottom Footer (decide what to display based on state)
     if (items.isNotEmpty()) {
-        if (isEndOfList) {
+        if (appendError != null) {
+            item(key = "footer_error_of_list") {
+                EndOfListFooter(message = appendError)
+            }
+        } else if (isEndOfList) {
             // Case A: Already at the end -> Show "No more data"
             item(key = "footer_end_of_list") {
-                EndOfListFooter()
+                EndOfListFooter(message = "No more data")
             }
         } else {
             // Case B: Not yet at the end -> Show "Loading Spinner"
@@ -78,6 +83,7 @@ inline fun <T> LazyListScope.pagingItems(
 inline fun <T> LazyGridScope.pagingGridItems(
     items: List<T>,
     isEndOfList: Boolean,
+    appendError: String?,
     noinline onLoadMore: () -> Unit,
     noinline key: ((item: T) -> Any)? = null,
     crossinline itemContent: @Composable (item: T) -> Unit
@@ -104,8 +110,10 @@ inline fun <T> LazyGridScope.pagingGridItems(
             // Key: Make the Footer occupy all columns of the row
             span = { GridItemSpan(maxLineSpan) }
         ) {
-            if (isEndOfList) {
-                EndOfListFooter()
+            if (appendError != null) {
+                EndOfListFooter(message = appendError)
+            } else if (isEndOfList) {
+                EndOfListFooter(message = " No more data")
             } else {
                 LoadingFooter()
             }
@@ -121,6 +129,7 @@ inline fun <T> LazyGridScope.pagingGridItems(
 inline fun <T> LazyStaggeredGridScope.pagingStaggeredGridItems(
     items: List<T>,
     isEndOfList: Boolean,
+    appendError: String?,
     noinline onLoadMore: () -> Unit,
     noinline key: ((item: T) -> Any)? = null,
     crossinline itemContent: @Composable (item: T) -> Unit
@@ -147,8 +156,10 @@ inline fun <T> LazyStaggeredGridScope.pagingStaggeredGridItems(
             // Make the Footer span all columns (FullLine)
             span = StaggeredGridItemSpan.FullLine
         ) {
-            if (isEndOfList) {
-                EndOfListFooter()
+            if (appendError != null) {
+                EndOfListFooter(message = appendError)
+            } else if (isEndOfList) {
+                EndOfListFooter(message = " No more data")
             } else {
                 LoadingFooter()
             }

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/CollectionContract.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/CollectionContract.kt
@@ -21,8 +21,9 @@ data class CollectionDetailUiState(
     val photosState: AppUiState<List<GalleryDisplayable>> = AppUiState.Idle,
 
     // List pagination control
-    val isPhotosLoadingMore: Boolean = false,
+    val isRefreshing: Boolean = false,
     val isPhotosEndOfList: Boolean = false,
+    val photosAppendError: String? = null,
     val photosPage: Int = 1
 )
 

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/CollectionScreen.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/CollectionScreen.kt
@@ -52,8 +52,7 @@ import coil3.compose.AsyncImage
 import io.lackstudio.omnifeed.ui.state.AppUiState
 import io.lackstudio.omnihub.compose.ui.components.ExpandableText
 import io.lackstudio.omnihub.compose.ui.navigation.Feature
-import io.lackstudio.omnihub.compose.ui.navigation.XrNavEvent
-import io.lackstudio.omnihub.compose.utils.LocalXrNavigation
+import io.lackstudio.omnihub.compose.ui.navigation.rememberGalleryNavigator
 import io.lackstudio.omnihub.compose.utils.UnsplashLinks
 import io.lackstudio.omnihub.compose.utils.logging.rememberLogger
 import omnihub.compose.generated.resources.Res
@@ -75,10 +74,11 @@ fun CollectionDetailScreen(
     animatedVisibilityScope: AnimatedVisibilityScope
 ) {
     val logger = rememberLogger("CollectionDetailScreen")
+    val navigator = rememberGalleryNavigator(onNavigateToFeature)
 
     val state by viewModel.state.collectAsStateWithLifecycle()
     val uriHandler = LocalUriHandler.current
-    val xrNav = LocalXrNavigation.current
+//    val xrNav = LocalXrNavigation.current
 
     LaunchedEffect(collectionId) {
          viewModel.handleIntent(CollectionDetailIntent.LoadData(collectionId))
@@ -124,23 +124,15 @@ fun CollectionDetailScreen(
         ) {
             CollectionDetailContent(
                 state = state,
-                onNavigateToPhoto = { id, url, ratio ->
-                    if (xrNav != null) {
-                        xrNav(XrNavEvent.NavigateToPhoto(id, url, ratio))
-                    } else {
-                        onNavigateToFeature(Feature.Photo(id, url))
-                    }
-                },
-                onNavigateToUser = { username ->
-                    if (xrNav != null) {
-                        xrNav(XrNavEvent.NavigateToUser(username))
-                    } else {
-                        onNavigateToFeature(Feature.User(username))
-                    }
-                },
+                onItemClick = navigator::navigateToPhoto,
+                onUserClick = navigator::navigateToUser,
                 onLoadMore = {
                     logger.d { "CollectionDetailScreen: onLoadMore" }
                     viewModel.handleIntent(CollectionDetailIntent.LoadMorePhotos)
+                },
+                onRefresh = {
+                    logger.d { "CollectionDetailScreen: onRefresh" }
+                    viewModel.handleIntent(CollectionDetailIntent.Refresh)
                 },
                 sharedTransitionScope = sharedTransitionScope,
                 animatedVisibilityScope = animatedVisibilityScope
@@ -153,75 +145,82 @@ fun CollectionDetailScreen(
 @Composable
 fun CollectionDetailContent(
     state: CollectionDetailUiState,
-    onNavigateToPhoto: (String, String, Float) -> Unit,
-    onNavigateToUser: (String) -> Unit,
+    onItemClick: (GalleryDisplayable) -> Unit,
+    onUserClick: (String) -> Unit,
     onLoadMore: () -> Unit,
+    onRefresh: () -> Unit,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
-        when (val infoState = state.infoState) {
-            is AppUiState.Loading, AppUiState.Idle -> {
-                // Simple Header Loading placeholder
-                Box(
-                    modifier = Modifier.fillMaxWidth().padding(16.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
-                }
-            }
-            is AppUiState.Error -> {
-                Box(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-                    Text(
-                        text = "Failed to load info: ${infoState.message}",
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            }
-            is AppUiState.Success -> {
-                Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)) {
-                    CollectionHeader(
-                        info = infoState.data,
-                        onUserClick = onNavigateToUser
-                    )
-                }
-                HorizontalDivider(modifier = Modifier.padding(bottom = 8.dp))
-            }
-        }
-
-        // --- Photo List Section ---
-        // Handle state and type conversion.
-        // We need to convert AppUiState<List<CollectionPhoto>> to AppUiState<List<GalleryDisplayable>>,
-        // or convert the data directly in the Success state.
-        when (val photosState = state.photosState) {
-            is AppUiState.Loading, AppUiState.Idle -> {
-                Box(modifier = Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator()
-                }
-            }
-            is AppUiState.Error -> {
-                Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                    Text("Failed to load photos", color = MaterialTheme.colorScheme.error)
-                }
-            }
-            is AppUiState.Success -> {
-                val photos = photosState.data
-                if (photos.isEmpty()) {
-                    Box(modifier = Modifier.height(100.dp).fillMaxWidth(), contentAlignment = Alignment.Center) {
-                        Text("No photos in this topic", color = Color.Gray)
+    SafePullToRefreshBox(
+        isRefreshing = state.isRefreshing,
+        onRefresh = onRefresh,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            when (val infoState = state.infoState) {
+                is AppUiState.Loading, AppUiState.Idle -> {
+                    // Simple Header Loading placeholder
+                    Box(
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
                     }
-                } else {
-                    // Use the shared PhotoList component.
-                    PhotoList(
-                        photos = photos,
-                        sharedTransitionScope = sharedTransitionScope,
-                        animatedVisibilityScope = animatedVisibilityScope,
-                        isEndOfList = state.isPhotosEndOfList,
-                        onLoadMore = onLoadMore,
-                        onPhotoClick = onNavigateToPhoto,
-                        onUserClick = onNavigateToUser
-                    )
+                }
+                is AppUiState.Error -> {
+                    Box(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                        Text(
+                            text = "Failed to load info: ${infoState.message}",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+                is AppUiState.Success -> {
+                    Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)) {
+                        CollectionHeader(
+                            info = infoState.data,
+                            onUserClick = onUserClick
+                        )
+                    }
+                    HorizontalDivider(modifier = Modifier.padding(bottom = 8.dp))
+                }
+            }
+
+            // --- Photo List Section ---
+            // Handle state and type conversion.
+            // We need to convert AppUiState<List<CollectionPhoto>> to AppUiState<List<GalleryDisplayable>>,
+            // or convert the data directly in the Success state.
+            when (val photosState = state.photosState) {
+                is AppUiState.Loading, AppUiState.Idle -> {
+                    Box(modifier = Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                is AppUiState.Error -> {
+                    Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                        Text("Failed to load photos", color = MaterialTheme.colorScheme.error)
+                    }
+                }
+                is AppUiState.Success -> {
+                    val photos = photosState.data
+                    if (photos.isEmpty()) {
+                        Box(modifier = Modifier.height(100.dp).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                            Text("No photos in this topic", color = Color.Gray)
+                        }
+                    } else {
+                        GalleryDisplayableList(
+                            items = photos,
+                            isEndOfList = state.isPhotosEndOfList,
+                            appendError = state.photosAppendError,
+                            onLoadMore = onLoadMore,
+                            onItemClick = onItemClick,
+                            onUserClick = onUserClick,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedVisibilityScope = animatedVisibilityScope
+                        )
+                    }
                 }
             }
         }
@@ -376,9 +375,10 @@ private fun CollectionDetailContentPreview() {
                                 infoState = AppUiState.Success(mockCollection),
                                 photosState = AppUiState.Success(mockPhotos)
                             ),
-                            onNavigateToPhoto = { _, _, _-> },
-                            onNavigateToUser = {},
+                            onItemClick = { },
+                            onUserClick = {},
                             onLoadMore = {},
+                            onRefresh = {},
                             sharedTransitionScope = this@SharedTransitionLayout,
                             animatedVisibilityScope = this@AnimatedVisibility
                         )
@@ -401,9 +401,10 @@ private fun CollectionDetailLoadingPreview() {
                         infoState = AppUiState.Loading,
                         photosState = AppUiState.Loading
                     ),
-                    onNavigateToPhoto = { _, _, _ -> },
-                    onNavigateToUser = {},
+                    onItemClick = { },
+                    onUserClick = {},
                     onLoadMore = {},
+                    onRefresh = {},
                     sharedTransitionScope = this@SharedTransitionLayout,
                     animatedVisibilityScope = this@AnimatedVisibility
                 )

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/CollectionViewModel.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/CollectionViewModel.kt
@@ -19,6 +19,8 @@ class CollectionViewModel(
 
     private var currentCollectionId: String? = null
 
+    private var internalLoading = false
+
     fun handleIntent(intent: CollectionDetailIntent) {
         when (intent) {
             is CollectionDetailIntent.LoadData -> {
@@ -33,6 +35,7 @@ class CollectionViewModel(
             }
             is CollectionDetailIntent.Refresh -> {
                 logger.d { "handleIntent: Refresh" }
+                _state.update { it.copy(isRefreshing = true) }
                 currentCollectionId?.let { id ->
                     loadCollectionInfo(id)
                     loadCollectionPhotos(id, isRefresh = true)
@@ -40,6 +43,13 @@ class CollectionViewModel(
             }
             is CollectionDetailIntent.LoadMorePhotos -> {
                 logger.d { "handleIntent: LoadMorePhotos" }
+                val currentState = _state.value
+
+                if (internalLoading) return
+                if (currentState.isRefreshing) return
+                if (currentState.isPhotosEndOfList) return
+                if (currentState.photosAppendError != null) return
+
                 currentCollectionId?.let { id ->
                     loadCollectionPhotos(id, isRefresh = false)
                 }
@@ -54,7 +64,11 @@ class CollectionViewModel(
             useCase = { getCollectionUseCase(id) },
             onLoading = {
                 // Set Info state to Loading
-                _state.update { it.copy(infoState = AppUiState.Loading) }
+                _state.update { currentState ->
+                    // Anti-flickering: Keep current state instead of reverting to Loading if old data exists
+                    if (currentState.infoState is AppUiState.Success) currentState
+                    else currentState.copy(infoState = AppUiState.Loading)
+                }
             },
             onSuccess = { domainCollection ->
                 // Convert Domain Model to UI Model (Collection) here
@@ -80,25 +94,23 @@ class CollectionViewModel(
     // --- Part 2: Collection Photos (Pagination) ---
     private fun loadCollectionPhotos(id: String, isRefresh: Boolean) {
         val currentState = _state.value
-
-        // Guard: If LoadMore and currently loading or reached end of list, do not execute
-        if (!isRefresh && (currentState.isPhotosLoadingMore || currentState.isPhotosEndOfList)) {
-            logger.d { "loadCollectionPhotos: Guard triggered" }
-            return
-        }
-
         val page = if (isRefresh) 1 else currentState.photosPage + 1
+
+        if (page > 1) internalLoading = true
+
         val params = GetCollectionPhotosParams(id = id, page = page, perPage = 10)
         handleUseCaseCall(
             name = "Collection Photos",
             useCase = { getCollectionPhotosUseCase(params) },
             onLoading = {
-                if (isRefresh) {
-                    // Pull-to-refresh or first load: Show Loading for the whole list
-                    _state.update { it.copy(photosState = AppUiState.Loading) }
-                } else {
-                    // Load more: Keep list displayed, only show bottom Loading
-                    _state.update { it.copy(isPhotosLoadingMore = true) }
+                _state.update { state ->
+                    val oldList = (state.photosState as? AppUiState.Success)?.data
+                    // If the list has old data, do not show full-screen Loading
+                    if (!oldList.isNullOrEmpty()) {
+                        state
+                    } else {
+                        state.copy(photosState = AppUiState.Loading)
+                    }
                 }
             },
             onSuccess = { domainPhotos ->
@@ -118,32 +130,43 @@ class CollectionViewModel(
                     )
                 }
 
-                _state.update { oldState ->
+                _state.update { currentState ->
                     // Logic: If Refresh, use new data directly; if LoadMore, append new data to old data
-                    val combinedPhotos = if (isRefresh) {
-                        newPhotos
-                    } else {
-                        val currentList = (oldState.photosState as? AppUiState.Success)?.data ?: emptyList()
-                        currentList + newPhotos
-                    }
+                    val oldList =
+                        if (isRefresh) emptyList()
+                        else (currentState.photosState as? AppUiState.Success)?.data ?: emptyList()
 
-                    oldState.copy(
+                    val combinedPhotos = (oldList + newPhotos).distinctBy { it.displayId }
+
+                    currentState.copy(
                         photosState = AppUiState.Success(combinedPhotos),
                         photosPage = page,
-                        isPhotosLoadingMore = false,
+                        isRefreshing = false,
+                        photosAppendError = null,
                         // If returned data is empty, the end of the list has been reached
                         isPhotosEndOfList = newPhotos.isEmpty()
                     )
                 }
+                if (page > 1) internalLoading = false
             },
             onError = { msg ->
                 logger.e { "Error loading collection photos: $msg" }
-                if (isRefresh) {
-                    _state.update { it.copy(photosState = AppUiState.Error(msg)) }
-                } else {
-                    // LoadMore failed, just turn off Loading state, keep the original list
-                    // (Advanced: use SideEffect to show Snackbar error)
-                    _state.update { it.copy(isPhotosLoadingMore = false) }
+                _state.update { currentState ->
+                    val oldList = (currentState.photosState as? AppUiState.Success)?.data
+
+                    // Prevent clearing: As long as there is old data, only set the error to appendError
+                    if (!oldList.isNullOrEmpty()) {
+                        currentState.copy(
+                            photosAppendError = msg,
+                            isRefreshing = false
+                        )
+                    } else {
+                        currentState.copy(
+                            photosState = AppUiState.Error(msg),
+                            photosAppendError = null,
+                            isRefreshing = false
+                        )
+                    }
                 }
             }
         )

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/GalleryComponents.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/GalleryComponents.kt
@@ -1,8 +1,13 @@
 package io.lackstudio.omnihub.compose.ui.gallery
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -33,9 +38,12 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FilterNone
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -44,6 +52,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -68,6 +78,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.size.Size
 import com.brys.compose.blurhash.BlurHashImage
+import io.lackstudio.omnifeed.ui.state.AppUiState
 import io.lackstudio.omnihub.compose.platform.isPullToRefreshSupported // Variable defined recently
 import io.lackstudio.omnihub.compose.ui.extensions.pagingGridItems
 import io.lackstudio.omnihub.compose.ui.extensions.pagingStaggeredGridItems
@@ -99,97 +110,198 @@ fun SafePullToRefreshBox(
     }
 }
 
-// --- List Components ---
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-fun PhotoList(
-    photos: List<GalleryDisplayable>,
-    sharedTransitionScope: SharedTransitionScope,
-    animatedVisibilityScope: AnimatedVisibilityScope,
-    isEndOfList: Boolean,
-    onLoadMore: () -> Unit,
-    onPhotoClick: (String, String, Float) -> Unit,
-    onUserClick: (String) -> Unit = {}
+fun <T> StatefulListContent(
+    state: AppUiState<List<T>>,
+    isRefreshing: Boolean = false,
+    onRefresh: (() -> Unit)? = null,
+    emptyMessage: String,
+    // Let the caller decide what List to draw on success (pass the unwrapped List<T>)
+    successContent: @Composable (List<T>) -> Unit
 ) {
-    // Use Staggered Grid State
-    val state = rememberLazyStaggeredGridState()
-
-    LazyVerticalStaggeredGrid(
-        // Key setting: Adaptive
-        // Set minimum width (e.g., 300.dp or 180.dp)
-        // - On mobile (width < 600dp), it automatically becomes 1 or 2 columns
-        // - On Desktop/Web (large width), it automatically becomes 3, 4, 5... columns
-        // Value can be adjusted based on design, smaller value means more columns
-        columns = StaggeredGridCells.Adaptive(minSize = 300.dp),
-        modifier = Modifier.fillMaxSize(),
-        state = state,
-        contentPadding = PaddingValues(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalItemSpacing = 8.dp
-    ) {
-        // Use the newly added extension
-        pagingStaggeredGridItems(
-            items = photos,
-            isEndOfList = isEndOfList,
-            onLoadMore = onLoadMore,
-            key = { it.displayId }
-        ) { item ->
-            GalleryCard(
-                item = item,
-                onClick = {
-                    val ratio = item.displayWidth / item.displayHeight.toFloat()
-                    onPhotoClick(item.displayId, item.displayImageUrl?: "", ratio)
-                },
-                onUserClick = { item.displayUsername?.let { onUserClick(it) } },
-                sharedTransitionScope = sharedTransitionScope,
-                animatedVisibilityScope = animatedVisibilityScope)
+    // Determine if a pull-to-refresh wrapper is needed
+    val contentWrapper: @Composable (@Composable () -> Unit) -> Unit = { child ->
+        if (onRefresh != null) {
+            SafePullToRefreshBox(
+                isRefreshing = isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.fillMaxSize()
+            ) { child() }
+        } else {
+            Box(modifier = Modifier.fillMaxSize()) { child() }
         }
     }
-}
 
-@OptIn(ExperimentalSharedTransitionApi::class)
-@Composable
-fun CollectionList(
-    collections: List<GalleryDisplayable>,
-    isEndOfList: Boolean,
-    onLoadMore: () -> Unit,
-    onCollectionClick: (String, String) -> Unit,
-    onUserClick: (String) -> Unit = {}
-) {
-    // Use Staggered Grid State
-    val state = rememberLazyStaggeredGridState()
+    contentWrapper {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            when (state) {
+                is AppUiState.Idle, is AppUiState.Loading -> CircularProgressIndicator()
 
-    LazyVerticalStaggeredGrid(
-        columns = StaggeredGridCells.Adaptive(minSize = 300.dp),
-        modifier = Modifier.fillMaxSize(),
-        state = state,
-        contentPadding = PaddingValues(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalItemSpacing = 8.dp
-    ) {
-        pagingStaggeredGridItems(
-            items = collections,
-            isEndOfList = isEndOfList,
-            onLoadMore = onLoadMore,
-            key = { it.displayId }
-        ) { collection ->
-            GalleryCard(
-                item = collection,
-                onClick = { onCollectionClick(collection.displayId, collection.displayTitle) },
-                onUserClick = {
-                    collection.displayUsername?.let {
-                        onUserClick(it)
+                is AppUiState.Error -> Text(
+                    text = state.message,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(16.dp)
+                )
+
+                is AppUiState.Success -> {
+                    val data = state.data
+                    if (data.isEmpty()) {
+                        Text(emptyMessage, color = Color.Gray)
+                    } else {
+                        successContent(data)
                     }
                 }
-            )
+            }
         }
     }
 }
 
+@Composable
+fun TopicPagedSection(
+    state: AppUiState<List<GalleryTopic>>,
+    isRefreshing: Boolean = false,
+    onRefresh: (() -> Unit)? = null,
+    isEndOfList: Boolean,
+    appendError: String?,
+    emptyMessage: String = "No topics found.",
+    onLoadMore: () -> Unit,
+    onTopicClick: (String, String) -> Unit
+) {
+    StatefulListContent(
+        state = state,
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        emptyMessage = emptyMessage
+    ) { topics ->
+        TopicList(
+            topics = topics,
+            isEndOfList = isEndOfList,
+            appendError = appendError,
+            onLoadMore = onLoadMore,
+            onTopicClick = onTopicClick
+        )
+    }
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun GalleryPagedSection(
+    state: AppUiState<List<GalleryDisplayable>>,
+    isRefreshing: Boolean = false,
+    onRefresh: (() -> Unit)? = null,
+    isEndOfList: Boolean,
+    appendError: String?,
+    emptyMessage: String,
+    onLoadMore: () -> Unit,
+    onItemClick: (GalleryDisplayable) -> Unit,
+    onUserClick: (String) -> Unit = {},
+    sharedTransitionScope: SharedTransitionScope? = null,
+    animatedVisibilityScope: AnimatedVisibilityScope? = null
+) {
+    StatefulListContent(
+        state = state,
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        emptyMessage = emptyMessage
+    ) { items ->
+        GalleryDisplayableList(
+            items = items,
+            isEndOfList = isEndOfList,
+            appendError = appendError,
+            onLoadMore = onLoadMore,
+            onItemClick = onItemClick,
+            onUserClick = onUserClick,
+            sharedTransitionScope = sharedTransitionScope,
+            animatedVisibilityScope = animatedVisibilityScope
+        )
+    }
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun GalleryDisplayableList(
+    items: List<GalleryDisplayable>,
+    isEndOfList: Boolean,
+    appendError: String?,
+    onLoadMore: () -> Unit,
+    onItemClick: (GalleryDisplayable) -> Unit,
+    onUserClick: (String) -> Unit = {},
+    sharedTransitionScope: SharedTransitionScope? = null,
+    animatedVisibilityScope: AnimatedVisibilityScope? = null
+) {
+    val state = rememberLazyStaggeredGridState()
+    val coroutineScope = rememberCoroutineScope()
+
+    val showFab by remember {
+        derivedStateOf { state.firstVisibleItemIndex > 2 }
+    }
+    Box(modifier = Modifier.fillMaxSize()) {
+
+        LazyVerticalStaggeredGrid(
+            // Key setting: Adaptive
+            // Set minimum width (e.g., 300.dp or 180.dp)
+            // - On mobile (width < 600dp), it automatically becomes 1 or 2 columns
+            // - On Desktop/Web (large width), it automatically becomes 3, 4, 5... columns
+            // Value can be adjusted based on design, smaller value means more columns
+            columns = StaggeredGridCells.Adaptive(minSize = 300.dp),
+            modifier = Modifier.fillMaxSize(),
+            state = state,
+            contentPadding = PaddingValues(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalItemSpacing = 8.dp
+        ) {
+            pagingStaggeredGridItems(
+                items = items,
+                isEndOfList = isEndOfList,
+                appendError = appendError,
+                onLoadMore = onLoadMore,
+                key = { it.displayId }
+            ) { item ->
+                GalleryCard(
+                    item = item,
+                    onClick = { onItemClick(item) },
+                    onUserClick = { item.displayUsername?.let { onUserClick(it) } },
+                    sharedTransitionScope = sharedTransitionScope,
+                    animatedVisibilityScope = animatedVisibilityScope
+                )
+            }
+        }
+
+        AnimatedVisibility(
+            visible = showFab,
+            enter = fadeIn() + scaleIn(),
+            exit = fadeOut() + scaleOut(),
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp) // Margin from the bottom right corner
+        ) {
+            FloatingActionButton(
+                onClick = {
+                    coroutineScope.launch {
+                        // Magic to instantly unlock pull-to-refresh: force the list to scroll back to absolute 0 position!
+                        state.animateScrollToItem(0)
+                    }
+                },
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(48.dp) // Button size can be fine-tuned according to preference
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.KeyboardArrowUp,
+                    contentDescription = "Scroll to top"
+                )
+            }
+        }
+    }
+}
+
+// --- List Components ---
 @Composable
 fun TopicList(
     topics: List<GalleryTopic>,
     isEndOfList: Boolean,
+    appendError: String?,
     onLoadMore: () -> Unit,
     onTopicClick: (String, String) -> Unit
 ) {
@@ -203,6 +315,7 @@ fun TopicList(
         pagingGridItems(
             items = topics,
             isEndOfList = isEndOfList,
+            appendError = appendError,
             onLoadMore = onLoadMore,
             key = { topic -> topic.id }
         ) { topic ->

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/GalleryContract.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/GalleryContract.kt
@@ -131,18 +131,15 @@ enum class GalleryTab(
 data class GalleryUiState(
     // Global state
     val currentTab: GalleryTab = GalleryTab.Photos,
-
     // Use Map to track the refreshing status of each Tab
     val refreshingStatus: Map<GalleryTab, Boolean> = emptyMap(),
+    val endOfListStatus: Map<GalleryTab, Boolean> = emptyMap(),
+    val pages: Map<GalleryTab, Int> = emptyMap(),
+    val appendError: Map<GalleryTab, String> = emptyMap(),
 
     val photosState: AppUiState<List<GalleryPhoto>> = AppUiState.Idle,
-    val photosEndOfList: Boolean = false,
-
     val collectionsState: AppUiState<List<GalleryCollection>> = AppUiState.Idle,
-    val collectionsEndOfList: Boolean = false,
-
     val topicsState: AppUiState<List<GalleryTopic>> = AppUiState.Idle,
-    val topicsEndOfList: Boolean = false,
 
     val meProfile: Me? = null,
     val isAuthenticating: Boolean = false

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/GalleryScreen.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/GalleryScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.focusable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -52,8 +51,7 @@ import io.lackstudio.omnifeed.ui.state.AppUiState
 import io.lackstudio.omnihub.compose.platform.isPullToRefreshSupported
 import io.lackstudio.omnihub.compose.ui.components.MonitorErrorStates
 import io.lackstudio.omnihub.compose.ui.navigation.Feature
-import io.lackstudio.omnihub.compose.ui.navigation.XrNavEvent
-import io.lackstudio.omnihub.compose.utils.LocalXrNavigation
+import io.lackstudio.omnihub.compose.ui.navigation.rememberGalleryNavigator
 import io.lackstudio.omnihub.compose.utils.logging.rememberLogger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -80,6 +78,7 @@ fun GalleryScreen(
     animatedVisibilityScope: AnimatedVisibilityScope
 ) {
     val logger = rememberLogger(tag)
+    val navigator = rememberGalleryNavigator(onNavigateToFeature)
     // Collect ViewModel state
     val state by viewModel.state.collectAsStateWithLifecycle()
     val sideEffectFlow = viewModel.sideEffect
@@ -118,6 +117,8 @@ fun GalleryScreen(
         state = state,
         // Pass SideEffect Flow (receive ViewModel one-time events)
         sideEffectFlow = sideEffectFlow,
+        onItemClick = navigator::navigateToPhoto,
+        onUserClick = navigator::navigateToUser,
         onEvent = { event ->
             logger.d { "Event: $event" }
             viewModel.handleIntent(event)
@@ -138,6 +139,8 @@ fun GalleryScreen(
 fun GalleryScreenContent(
     state: GalleryUiState,          // Receive pure data state
     sideEffectFlow: Flow<GallerySideEffect>, // Receive onetime event
+    onItemClick: (GalleryDisplayable) -> Unit,
+    onUserClick: (String) -> Unit,
     onEvent: (GalleryIntent) -> Unit, // Receive event callbacks
     onNavigateToFeature: (Feature) -> Unit,
     onBack: () -> Unit,
@@ -152,6 +155,7 @@ fun GalleryScreenContent(
 
     val lifecycleOwner = LocalLifecycleOwner.current
     val uriHandler = LocalUriHandler.current
+
     // Observe SideEffect and ensure Snackbar events are received only when in foreground
     // Use flowWithLifecycle to bind lifecycle
     // Safety: When the App goes to background (STOPPED), collection is automatically "paused" to avoid wasting resources on UI actions.
@@ -354,170 +358,58 @@ fun GalleryScreenContent(
                 // Keep the state of 1 page on each side to avoid resetting scroll position when switching
                 beyondViewportPageCount = 1
             ) { pageIndex ->
+                val tab = tabs[pageIndex]
+                val isEndOfList = state.endOfListStatus[tab] ?: false
+                val isRefreshing = state.refreshingStatus[tab] ?: false
+                val currentError = state.appendError[tab]?.takeIf { it.isNotBlank() }
+
                 when (tabs[pageIndex]) {
-                    GalleryTab.Photos -> PhotosContent(
-                        state = state.photosState,
-                        isRefreshing = state.refreshingStatus[GalleryTab.Photos] ?: false,
-                        onRefresh = { onEvent(GalleryIntent.Refresh) },
-                        isEndOfList = state.photosEndOfList,
-                        onLoadMore = { onEvent(GalleryIntent.LoadMore) },
-                        onNavigateToFeature = onNavigateToFeature,
-                        sharedTransitionScope = sharedTransitionScope,
-                        animatedVisibilityScope = animatedVisibilityScope
-                    )
-                    GalleryTab.Collections -> CollectionsContent(
-                        state = state.collectionsState,
-                        isRefreshing = state.refreshingStatus[GalleryTab.Collections] ?: false,
-                        onRefresh = { onEvent(GalleryIntent.Refresh) },
-                        isEndOfList = state.collectionsEndOfList,
-                        onLoadMore = { onEvent(GalleryIntent.LoadMore) },
-                        onNavigateToFeature = onNavigateToFeature
-                    )
-                    GalleryTab.Topics -> TopicsContent(
-                        state = state.topicsState,
-                        isRefreshing = state.refreshingStatus[GalleryTab.Topics] ?: false,
-                        onRefresh = { onEvent(GalleryIntent.Refresh) },
-                        isEndOfList = state.topicsEndOfList,
-                        onLoadMore = { onEvent(GalleryIntent.LoadMore) },
-                        onNavigateToFeature = onNavigateToFeature
-                    )
-                }
-            }
-        }
-    }
-}
-
-// --- Content Sub-pages (Updated with onLoadMore) ---
-@OptIn(ExperimentalSharedTransitionApi::class)
-@Composable
-fun PhotosContent(
-    state: AppUiState<List<GalleryPhoto>>,
-    isRefreshing: Boolean,
-    onRefresh: () -> Unit,
-    isEndOfList: Boolean,
-    onLoadMore: () -> Unit,
-    onNavigateToFeature: (Feature) -> Unit,
-    sharedTransitionScope: SharedTransitionScope,
-    animatedVisibilityScope: AnimatedVisibilityScope
-) {
-    val xrNav = LocalXrNavigation.current
-    SafePullToRefreshBox(
-        isRefreshing = isRefreshing,
-        onRefresh = onRefresh,
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            when (state) {
-                is AppUiState.Idle, is AppUiState.Loading -> CircularProgressIndicator()
-                is AppUiState.Error -> Text(
-                    "Error: ${state.message}",
-                    color = MaterialTheme.colorScheme.error
-                )
-
-                is AppUiState.Success -> {
-                    if (state.data.isEmpty()) Text("No photos found.")
-                    else PhotoList(
-                        state.data,
-                        sharedTransitionScope = sharedTransitionScope,
-                        animatedVisibilityScope = animatedVisibilityScope,
-                        isEndOfList = isEndOfList,
-                        onLoadMore = onLoadMore,
-                        onPhotoClick = { id, url, ratio ->
-                            if (xrNav != null) {
-                                xrNav(XrNavEvent.NavigateToPhoto(id, url, ratio))
-                            } else {
-                                onNavigateToFeature(Feature.Photo(id, url))
+                    GalleryTab.Photos -> {
+                        GalleryPagedSection(
+                            state = state.photosState,
+                            isRefreshing = isRefreshing,
+                            onRefresh = { onEvent(GalleryIntent.Refresh) },
+                            isEndOfList = isEndOfList,
+                            appendError = currentError,
+                            emptyMessage = "No photos found.",
+                            onLoadMore = { onEvent(GalleryIntent.LoadMore) },
+                            onItemClick = onItemClick,
+                            onUserClick = onUserClick,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedVisibilityScope = animatedVisibilityScope
+                        )
+                    }
+                    GalleryTab.Collections -> {
+                        GalleryPagedSection(
+                            state = state.collectionsState,
+                            isRefreshing = isRefreshing,
+                            onRefresh = { onEvent(GalleryIntent.Refresh) },
+                            isEndOfList = isEndOfList,
+                            appendError = currentError,
+                            emptyMessage = "No collections found",
+                            onLoadMore = { onEvent(GalleryIntent.LoadMore) },
+                            onItemClick = { item ->
+                                onNavigateToFeature(Feature.Collection(item.displayId, item.displayTitle))
+                            },
+                            onUserClick = onUserClick,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedVisibilityScope = animatedVisibilityScope
+                        )
+                    }
+                    GalleryTab.Topics -> {
+                        TopicPagedSection(
+                            state = state.topicsState,
+                            isRefreshing = isRefreshing,
+                            onRefresh = { onEvent(GalleryIntent.Refresh) },
+                            isEndOfList = isEndOfList,
+                            appendError = currentError,
+                            emptyMessage = "No topics found",
+                            onLoadMore = { onEvent(GalleryIntent.LoadMore) },
+                            onTopicClick = { id, title ->
+                                onNavigateToFeature(Feature.Topic(idOrSlug = id, title = title))
                             }
-                        },
-                        onUserClick = { username ->
-                            if (xrNav != null) {
-                                xrNav(XrNavEvent.NavigateToUser(username))
-                            } else {
-                                onNavigateToFeature(Feature.User(username))
-                            }
-                        }
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun CollectionsContent(
-    state: AppUiState<List<GalleryCollection>>,
-    isRefreshing: Boolean,
-    onRefresh: () -> Unit,
-    isEndOfList: Boolean,
-    onLoadMore: () -> Unit,
-    onNavigateToFeature: (Feature) -> Unit,
-) {
-    val xrNav = LocalXrNavigation.current
-    SafePullToRefreshBox(
-        isRefreshing = isRefreshing,
-        onRefresh = onRefresh,
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            when (state) {
-                is AppUiState.Idle, is AppUiState.Loading -> CircularProgressIndicator()
-                is AppUiState.Error -> Text("Error: ${state.message}", color = MaterialTheme.colorScheme.error)
-                is AppUiState.Success -> {
-                    if (state.data.isEmpty()) Text("No collections found.")
-                    else CollectionList(
-                        state.data,
-                        isEndOfList = isEndOfList,
-                        onLoadMore = onLoadMore,
-                        onCollectionClick = { id, title ->
-                            onNavigateToFeature(Feature.Collection(id, title))
-                        },
-                        onUserClick = { username ->
-                            if (xrNav != null) {
-                                xrNav(XrNavEvent.NavigateToUser(username))
-                            } else {
-                                onNavigateToFeature(Feature.User(username))
-                            }
-
-                        }
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun TopicsContent(
-    state: AppUiState<List<GalleryTopic>>,
-    isRefreshing: Boolean,
-    onRefresh: () -> Unit,
-    isEndOfList: Boolean,
-    onLoadMore: () -> Unit,
-    onNavigateToFeature: (Feature) -> Unit,
-) {
-    SafePullToRefreshBox(
-        isRefreshing = isRefreshing,
-        onRefresh = onRefresh,
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            when (state) {
-                is AppUiState.Idle, is AppUiState.Loading -> CircularProgressIndicator()
-                is AppUiState.Error -> Text(
-                    "Error: ${state.message}",
-                    color = MaterialTheme.colorScheme.error
-                )
-
-                is AppUiState.Success -> {
-                    if (state.data.isEmpty()) Text("No topics found.")
-                    else TopicList(
-                        state.data,
-                        isEndOfList = isEndOfList,
-                        onLoadMore,
-                        onTopicClick = { id, title ->
-                            onNavigateToFeature(Feature.Topic(idOrSlug = id, title = title ))
-                        }
-                    )
+                        )
+                    }
                 }
             }
         }
@@ -568,6 +460,8 @@ fun GalleryScreenPreview() {
             GalleryScreenContent(
                 state = dummyState,
                 sideEffectFlow = emptyFlow(),
+                onItemClick = {},
+                onUserClick = {},
                 onEvent = {},
                 onNavigateToFeature = {},
                 onBack = {},

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/GalleryViewModel.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/GalleryViewModel.kt
@@ -51,7 +51,7 @@ class GalleryViewModel(
 
     // Flag to prevent duplicate loading (avoid triggering API multiple times on scroll)
     // Use Map to track loading status of each Tab
-    private val loadingStatus = mutableMapOf<GalleryTab, Boolean>().withDefault { false }
+    private val internalLoadingMap = mutableMapOf<GalleryTab, Boolean>().withDefault { false }
 
     init {
         logger.d{"ViewModel init"}
@@ -94,19 +94,22 @@ class GalleryViewModel(
                 logger.d { "handleIntent: SelectTab tab=${intent.tab}" }
                 _state.update { it.copy(currentTab = intent.tab) }
                 logger.d { "handleIntent: currentTab=${_state.value.currentTab}" }
-                when (intent.tab) {
-                    // Check if Idle (means not loaded yet)
-                    GalleryTab.Photos -> if (_state.value.photosState is AppUiState.Idle) fetchPhotos(1)
-                    GalleryTab.Collections -> if (_state.value.collectionsState is AppUiState.Idle) fetchCollections(1)
-                    GalleryTab.Topics -> if (_state.value.topicsState is AppUiState.Idle) fetchTopics(1)
+                val shouldLoad = when(intent.tab) {
+                    GalleryTab.Photos -> _state.value.photosState is AppUiState.Idle
+                    GalleryTab.Collections -> _state.value.collectionsState is AppUiState.Idle
+                    GalleryTab.Topics -> _state.value.topicsState is AppUiState.Idle
+                }
+                if (shouldLoad) {
+                    loadContent(intent.tab, 1)
                 }
             }
             is GalleryIntent.Refresh -> {
-                logger.d { "handleIntent: Refresh" }
                 // Enable Refresh indicator
-                val currentTab = _state.value.currentTab
-                _state.update {
-                    it.copy(refreshingStatus = it.refreshingStatus + (currentTab to true))
+                _state.update { currentState ->
+                    logger.d { "handleIntent: Refresh" }
+                    currentState.copy(
+                        refreshingStatus = currentState.refreshingStatus +
+                                (currentState.currentTab to true))
                 }
                 // Execute refresh (force reload)
                 refreshCurrentTab()
@@ -195,27 +198,29 @@ class GalleryViewModel(
     }
 
     private fun loadNextPage() {
-        val currentTab = _state.value.currentTab
+        val currentState = _state.value
+        val currentTab = currentState.currentTab
         // Check if the Tab is currently loading
-        if (loadingStatus[currentTab] == true) return
+        if (internalLoadingMap[currentTab] == true) return
 
         // If refreshing, do not trigger load more to avoid data inconsistency
-        val isRefreshing = _state.value.refreshingStatus[currentTab] ?: false
+        val isRefreshing = currentState.refreshingStatus[currentTab] ?: false
         if (isRefreshing) return
 
         // Check if end of list (EndOfList) is reached, if so, do not load
-        val isEnd = when (_state.value.currentTab) {
-            GalleryTab.Photos -> _state.value.photosEndOfList
-            GalleryTab.Collections -> _state.value.collectionsEndOfList
-            GalleryTab.Topics -> _state.value.topicsEndOfList
-        }
-        if (isEnd) return
+        val isEndOfList = currentState.endOfListStatus[currentTab] ?: false
+        if (isEndOfList) return
 
-        // Determine what to load based on current Tab
-        when (_state.value.currentTab) {
-            GalleryTab.Photos -> fetchPhotos(photosPage + 1)
-            GalleryTab.Collections -> fetchCollections(collectionsPage + 1)
-            GalleryTab.Topics -> fetchTopics(topicsPage + 1)
+        val currentPage = currentState.pages[currentTab] ?: 1
+        val nextPage = currentPage + 1
+        loadContent(currentTab, nextPage)
+    }
+
+    private fun loadContent(tab: GalleryTab, page: Int) {
+        when(tab) {
+            GalleryTab.Photos -> fetchPhotos(page)
+            GalleryTab.Collections -> fetchCollections(page)
+            GalleryTab.Topics -> fetchTopics(page)
         }
     }
 
@@ -223,43 +228,37 @@ class GalleryViewModel(
      * Generic Helper function: Handle "Smart Loading" and "State Update" uniformly
      * @name Optional name for the UseCase
      * @param targetPage Target page number
-     * @param currentSubState Current state of the field (used for Loading check only)
      * @param getOldList Lambda to retrieve the *latest* list data at the moment of update
      * @param useCase API call logic
      * @param mapper Data transformation logic (Domain -> UI)
+     * @param distinctBy
      * @param stateReducer State update logic (specify which field of state to update)
-     * @param onSuccessUpdatePage Update current page number
      */
     private fun <T, R> fetchCategory(
         name: String = "fetchCategory",
         tab: GalleryTab,
         targetPage: Int,
-        currentSubState: AppUiState<List<R>>,
         getOldList: (GalleryUiState) -> List<R>?, // Function to retrieve the latest data dynamically
         useCase: suspend () -> UseCaseResult<List<T>>,
         mapper: (List<T>) -> List<R>,
         distinctBy: (R) -> Any,
-        stateReducer: (GalleryUiState, AppUiState<List<R>>, Boolean) -> GalleryUiState,
-        onSuccessUpdatePage: () -> Unit
+        stateReducer: (GalleryUiState, AppUiState<List<R>>) -> GalleryUiState,
     ) {
-        // Need to get the current Tab, or pass it as a parameter
-        val currentTab = _state.value.currentTab
-        // Prevent concurrent load-more requests.
-        if (targetPage > 1 && loadingStatus.getValue(currentTab)) return
-
-        // Set flag: If Page > 1, mark as loading more
-        if (targetPage > 1) loadingStatus[currentTab] = true
+        if (targetPage > 1 && internalLoadingMap.getValue(tab)) return
+        if (targetPage > 1) internalLoadingMap[tab] = true
 
         handleUseCaseCall(
             name = name,
             useCase = useCase,
             onLoading = {
-                // Show full page loading (AppUiState.Loading) only when "Page 1" and "no old data"
-                val hasOldData = targetPage > 1 || (currentSubState is AppUiState.Success && currentSubState.data.isNotEmpty())
+                _state.update { currentState ->
+                    val oldList = getOldList(currentState)
+                    val hasOldData = !oldList.isNullOrEmpty()
 
-                if (!hasOldData) {
-                    _state.update {
-                        stateReducer(it, AppUiState.Loading, false)
+                    if (!hasOldData) {
+                        stateReducer(currentState, AppUiState.Loading)
+                    } else {
+                        currentState
                     }
                 }
             },
@@ -267,41 +266,65 @@ class GalleryViewModel(
                 val newItems = mapper(resultData)
                 val isEndOfList = newItems.isEmpty()
 
-                onSuccessUpdatePage()
                 // Enter update block to get the "latest" state, instead of relying on the passed currentSubState
                 _state.update { currentState ->
-                    // 1. Dynamically retrieve old data (prevent Page 1 from being overwritten by Page 2 before it's written)
+                    // Get old data (if Page 1, clear it, representing Refresh)
                     val oldList = if (targetPage > 1) {
                         getOldList(currentState) ?: emptyList()
                     } else {
                         emptyList()
                     }
 
-                    // 2. Merge data
+                    // Merge data
                     val finalData = (oldList + newItems).distinctBy(distinctBy)
                     val finalSubState = AppUiState.Success(finalData)
 
                     // Turn off the refresh status of a specific Tab
-                    val newMap = currentState.refreshingStatus + (tab to false)
+                    val newPagesMap = currentState.pages + (tab to targetPage)
+                    val newRefreshMap = currentState.refreshingStatus + (tab to false)
+                    val newEndOfListMap = currentState.endOfListStatus + (tab to isEndOfList)
+                    val newErrorMap = currentState.appendError - tab
 
-                    // 3. Update State and ensure Refresh loading indicator is closed
-                    stateReducer(currentState, finalSubState, isEndOfList)
-                        .copy(refreshingStatus = newMap)
+                    // Update State and ensure Refresh or EndOfList loading indicator is closed
+                    stateReducer(currentState, finalSubState)
+                        .copy(
+                            refreshingStatus = newRefreshMap,
+                            endOfListStatus = newEndOfListMap,
+                            appendError = newErrorMap,
+                            pages = newPagesMap
+                        )
                 }
 
                 // Unlock flag
-                if (targetPage > 1) loadingStatus[currentTab] = false
+                if (targetPage > 1) internalLoadingMap[tab] = false
             },
-            onError = { exception ->
+            onError = { errorMessage ->
+                logger.d{"errorMessage: $errorMessage"}
                 _state.update { currentState ->
-                    val newMap = currentState.refreshingStatus + (tab to false)
-                    // Remember to close Refresh loading indicator even if an error occurs
-                    stateReducer(currentState, AppUiState.Error(exception), false)
-                        .copy(refreshingStatus = newMap)
+                    val newRefreshMap = currentState.refreshingStatus + (tab to false)
+                    val oldList = getOldList(currentState)
+
+                    if (!oldList.isNullOrEmpty()) {
+                        val newErrorMap = currentState.appendError + (tab to errorMessage)
+                        stateReducer(currentState, AppUiState.Success(oldList))
+                            .copy(
+                                refreshingStatus = newRefreshMap,
+                                appendError = newErrorMap
+                            )
+                    } else {
+                        // Only show a full-screen error when there is absolutely no data
+                        // (e.g., no internet on the first app launch).
+                        val newErrorMap = currentState.appendError - tab
+                        stateReducer(currentState, AppUiState.Error(errorMessage))
+                            .copy(
+                                refreshingStatus = newRefreshMap,
+                                appendError = newErrorMap
+                            )
+                    }
                 }
 
                 // Unlock flag
-                if (targetPage > 1) loadingStatus[currentTab] = false
+                if (targetPage > 1) internalLoadingMap[tab] = false
             }
         )
     }
@@ -313,7 +336,6 @@ class GalleryViewModel(
             name = "Photos",
             tab = GalleryTab.Photos,
             targetPage = page,
-            currentSubState = _state.value.photosState,
             // Pass Lambda to retrieve the latest data during merge
             getOldList = { state -> (state.photosState as? AppUiState.Success)?.data },
             useCase = { getPhotosUseCase(params) },
@@ -333,10 +355,11 @@ class GalleryViewModel(
                     )
                 } },
             distinctBy = { it.id },
-            stateReducer = { state, newState, isEnd ->
-                state.copy(photosState = newState, photosEndOfList = isEnd)
+            stateReducer = { state, newState ->
+                state.copy(
+                    photosState = newState,
+                )
             },
-            onSuccessUpdatePage = { photosPage = page }
         )
     }
 
@@ -347,7 +370,6 @@ class GalleryViewModel(
             name = "Collections",
             tab = GalleryTab.Collections,
             targetPage = page,
-            currentSubState = _state.value.collectionsState,
             // Pass Lambda to retrieve the latest data during merge
             getOldList = { state -> (state.collectionsState as? AppUiState.Success)?.data },
             useCase = { getCollectionsUseCase(params) },
@@ -374,10 +396,11 @@ class GalleryViewModel(
                     )
                 } },
             distinctBy = { it.id },
-            stateReducer = { state, newState, isEnd ->
-                state.copy(collectionsState = newState, collectionsEndOfList = isEnd)
+            stateReducer = { state, newState ->
+                state.copy(
+                    collectionsState = newState,
+                )
             },
-            onSuccessUpdatePage = { collectionsPage = page }
         )
     }
 
@@ -388,7 +411,6 @@ class GalleryViewModel(
             name = "Topics",
             tab = GalleryTab.Topics,
             targetPage = page,
-            currentSubState = _state.value.topicsState,
             // Pass Lambda to retrieve the latest data during merge
             getOldList = { state -> (state.topicsState as? AppUiState.Success)?.data },
             useCase = { getTopicsUseCase(params) },
@@ -408,10 +430,11 @@ class GalleryViewModel(
                     )
                 } },
             distinctBy = { it.id },
-            stateReducer = { state, newState, isEnd ->
-                state.copy(topicsState = newState, topicsEndOfList = isEnd)
+            stateReducer = { state, newState ->
+                state.copy(
+                    topicsState = newState,
+                )
             },
-            onSuccessUpdatePage = { topicsPage = page }
         )
     }
 

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/TopicContract.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/TopicContract.kt
@@ -22,8 +22,10 @@ data class TopicContributor(
 data class TopicDetailUiState(
     val infoState: AppUiState<Topic> = AppUiState.Idle,
     val photosState: AppUiState<List<GalleryDisplayable>> = AppUiState.Idle,
-    val isPhotosLoadingMore: Boolean = false,
+
+    val isRefreshing: Boolean = false,
     val isPhotosEndOfList: Boolean = false,
+    val photosAppendError: String? = null,
     val photosPage: Int = 1
 )
 

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/TopicScreen.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/TopicScreen.kt
@@ -30,8 +30,7 @@ import coil3.compose.AsyncImage
 import io.lackstudio.omnifeed.ui.state.AppUiState
 import io.lackstudio.omnihub.compose.ui.components.ExpandableText
 import io.lackstudio.omnihub.compose.ui.navigation.Feature
-import io.lackstudio.omnihub.compose.ui.navigation.XrNavEvent
-import io.lackstudio.omnihub.compose.utils.LocalXrNavigation
+import io.lackstudio.omnihub.compose.ui.navigation.rememberGalleryNavigator
 import io.lackstudio.omnihub.compose.utils.UnsplashLinks
 import io.lackstudio.omnihub.compose.utils.logging.rememberLogger
 import omnihub.compose.generated.resources.Res
@@ -51,10 +50,10 @@ fun TopicDetailScreen(
     animatedVisibilityScope: AnimatedVisibilityScope
 ) {
     val logger = rememberLogger("TopicDetailScreen")
-    val uriHandler = LocalUriHandler.current
+    val navigator = rememberGalleryNavigator(onNavigateToFeature)
 
+    val uriHandler = LocalUriHandler.current
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val xrNav = LocalXrNavigation.current
 
     LaunchedEffect(topicId) {
         viewModel.handleIntent(TopicDetailIntent.LoadData(topicId))
@@ -93,23 +92,15 @@ fun TopicDetailScreen(
         Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
             TopicDetailContent(
                 state = state,
-                onNavigateToPhoto = { id, url, ratio ->
-                    if (xrNav != null) {
-                        xrNav(XrNavEvent.NavigateToPhoto(id, url, ratio))
-                    } else {
-                        onNavigateToFeature(Feature.Photo(id, url))
-                    }
-                },
-                onNavigateToUser = { username ->
-                    if (xrNav != null) {
-                        xrNav(XrNavEvent.NavigateToUser(username))
-                    } else {
-                        onNavigateToFeature(Feature.User(username))
-                    }
-                },
+                onItemClick = navigator::navigateToPhoto,
+                onUserClick = navigator::navigateToUser,
                 onLoadMore = {
                     logger.d { "onLoadMore" }
                     viewModel.handleIntent(TopicDetailIntent.LoadMorePhotos)
+                },
+                onRefresh = {
+                    logger.d { "onRefresh" }
+                    viewModel.handleIntent(TopicDetailIntent.Refresh)
                 },
                 sharedTransitionScope = sharedTransitionScope,
                 animatedVisibilityScope = animatedVisibilityScope
@@ -122,67 +113,74 @@ fun TopicDetailScreen(
 @Composable
 fun TopicDetailContent(
     state: TopicDetailUiState,
-    onNavigateToPhoto: (String, String, Float) -> Unit,
-    onNavigateToUser: (String) -> Unit,
+    onItemClick: (GalleryDisplayable) -> Unit,
+    onUserClick: (String) -> Unit,
     onLoadMore: () -> Unit,
+    onRefresh: () -> Unit,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    SafePullToRefreshBox(
+        isRefreshing = state.isRefreshing,
+        onRefresh = onRefresh,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
 
-        // --- Header Section (Fixed at the top) ---
-        when (val infoState = state.infoState) {
-            is AppUiState.Loading, AppUiState.Idle -> {
-                Box(modifier = Modifier.fillMaxWidth().height(100.dp), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator()
-                }
-            }
-            is AppUiState.Error -> {
-                Text("Error: ${infoState.message}", color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(16.dp))
-            }
-            is AppUiState.Success -> {
-                Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                    TopicHeader(
-                        topic = infoState.data,
-                        onUserClick = onNavigateToUser
-                    )
-                }
-                HorizontalDivider(modifier = Modifier.padding(bottom = 8.dp))
-            }
-        }
-
-        // --- Photo List Section ---
-        // Handle state and type conversion
-        // We need to convert AppUiState<List<TopicPhoto>> to AppUiState<List<GalleryDisplayable>>
-        // Or convert data directly upon Success
-        when (val photosState = state.photosState) {
-            is AppUiState.Loading, AppUiState.Idle -> {
-                Box(modifier = Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator()
-                }
-            }
-            is AppUiState.Error -> {
-                Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                    Text("Failed to load photos", color = MaterialTheme.colorScheme.error)
-                }
-            }
-            is AppUiState.Success -> {
-                val photos = photosState.data
-                if (photos.isEmpty()) {
-                    Box(modifier = Modifier.height(100.dp).fillMaxWidth(), contentAlignment = Alignment.Center) {
-                        Text("No photos in this topic", color = Color.Gray)
+            // --- Header Section (Fixed at the top) ---
+            when (val infoState = state.infoState) {
+                is AppUiState.Loading, AppUiState.Idle -> {
+                    Box(modifier = Modifier.fillMaxWidth().height(100.dp), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
                     }
-                } else {
-                    // Use the shared PhotoList
-                    PhotoList(
-                        photos = photos,
-                        sharedTransitionScope = sharedTransitionScope,
-                        animatedVisibilityScope = animatedVisibilityScope,
-                        isEndOfList = state.isPhotosEndOfList,
-                        onLoadMore = onLoadMore,
-                        onPhotoClick = onNavigateToPhoto,
-                        onUserClick = onNavigateToUser
-                    )
+                }
+                is AppUiState.Error -> {
+                    Text("Error: ${infoState.message}", color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(16.dp))
+                }
+                is AppUiState.Success -> {
+                    Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                        TopicHeader(
+                            topic = infoState.data,
+                            onUserClick = onUserClick
+                        )
+                    }
+                    HorizontalDivider(modifier = Modifier.padding(bottom = 8.dp))
+                }
+            }
+
+            // --- Photo List Section ---
+            // Handle state and type conversion
+            // We need to convert AppUiState<List<TopicPhoto>> to AppUiState<List<GalleryDisplayable>>
+            // Or convert data directly upon Success
+            when (val photosState = state.photosState) {
+                is AppUiState.Loading, AppUiState.Idle -> {
+                    Box(modifier = Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                is AppUiState.Error -> {
+                    Box(modifier = Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                        Text("Failed to load photos", color = MaterialTheme.colorScheme.error)
+                    }
+                }
+                is AppUiState.Success -> {
+                    val photos = photosState.data
+                    if (photos.isEmpty()) {
+                        Box(modifier = Modifier.height(100.dp).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                            Text("No photos in this topic", color = Color.Gray)
+                        }
+                    } else {
+                        GalleryDisplayableList(
+                            items = photos,
+                            isEndOfList = state.isPhotosEndOfList,
+                            appendError = state.photosAppendError,
+                            onLoadMore = onLoadMore,
+                            onItemClick = onItemClick,
+                            onUserClick = onUserClick,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedVisibilityScope = animatedVisibilityScope
+                        )
+                    }
                 }
             }
         }
@@ -341,9 +339,10 @@ private fun TopicDetailContentPreview() {
                                 photosState = AppUiState.Success(mockPhotos),
                                 isPhotosEndOfList = false
                             ),
-                            onNavigateToPhoto = { _, _, _-> },
-                            onNavigateToUser = {},
+                            onItemClick = {},
+                            onUserClick = {},
                             onLoadMore = {},
+                            onRefresh = {},
                             sharedTransitionScope = this@SharedTransitionLayout,
                             animatedVisibilityScope = this@AnimatedVisibility
                         )
@@ -367,9 +366,10 @@ private fun TopicDetailLoadingPreview() {
                         photosState = AppUiState.Loading,
                         isPhotosEndOfList = false
                     ),
-                    onNavigateToPhoto = { _, _, _ -> },
-                    onNavigateToUser = {},
+                    onItemClick = {},
+                    onUserClick = {},
                     onLoadMore = {},
+                    onRefresh = {},
                     sharedTransitionScope = this@SharedTransitionLayout,
                     animatedVisibilityScope = this@AnimatedVisibility
                 )

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/TopicViewModel.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/TopicViewModel.kt
@@ -18,6 +18,7 @@ class TopicViewModel(
     val state = _state.asStateFlow()
 
     private var currentTopicId: String? = null
+    private var internalLoading = false
 
     fun handleIntent(intent: TopicDetailIntent) {
         when (intent) {
@@ -31,6 +32,7 @@ class TopicViewModel(
             }
             is TopicDetailIntent.Refresh -> {
                 logger.d { "handleIntent: Refresh" }
+                _state.update { it.copy(isRefreshing = true) }
                 currentTopicId?.let { id ->
                     loadTopicInfo(id)
                     loadTopicPhotos(id, isRefresh = true)
@@ -38,6 +40,12 @@ class TopicViewModel(
             }
             is TopicDetailIntent.LoadMorePhotos -> {
                 logger.d { "handleIntent: LoadMorePhotos" }
+                val currentState = _state.value
+
+                if (internalLoading) return
+                if (currentState.isRefreshing) return
+                if (currentState.isPhotosEndOfList) return
+                if (currentState.photosAppendError != null) return
                 currentTopicId?.let { id ->
                     loadTopicPhotos(id, isRefresh = false)
                 }
@@ -49,7 +57,12 @@ class TopicViewModel(
         handleUseCaseCall(
             name = "Topic",
             useCase = { getTopicUseCase(id) },
-            onLoading = { _state.update { it.copy(infoState = AppUiState.Loading) } },
+            onLoading = {
+                _state.update { currentState ->
+                    if (currentState.infoState is AppUiState.Success) currentState
+                    else currentState.copy(infoState = AppUiState.Loading)
+                }
+            },
             onSuccess = { domainTopic ->
                 // Convert Domain Model -> UI Model
                 val uiTopic = Topic(
@@ -76,17 +89,24 @@ class TopicViewModel(
 
     private fun loadTopicPhotos(id: String, isRefresh: Boolean) {
         val currentState = _state.value
-        if (!isRefresh && (currentState.isPhotosLoadingMore || currentState.isPhotosEndOfList)) return
-
         val page = if (isRefresh) 1 else currentState.photosPage + 1
+
+        if (page > 1) internalLoading = true
+
         val topicPhotoParams = GetTopicPhotosParams(id, page = page, perPage = 10)
 
         handleUseCaseCall(
             name = "Topic Photos",
             useCase = { getTopicPhotosUseCase(topicPhotoParams) },
             onLoading = {
-                if (isRefresh) _state.update { it.copy(photosState = AppUiState.Loading) }
-                else _state.update { it.copy(isPhotosLoadingMore = true) }
+                _state.update { state ->
+                    val oldList = (state.photosState as? AppUiState.Success)?.data
+                    if (!oldList.isNullOrEmpty()) {
+                        state
+                    } else {
+                        state.copy(photosState = AppUiState.Loading)
+                    }
+                }
             },
             onSuccess = { domainPhotos ->
                 val newPhotos = domainPhotos.map { photo ->
@@ -104,22 +124,43 @@ class TopicViewModel(
                     )
                 }
 
-                _state.update { oldState ->
-                    val combinedList = if (isRefresh) newPhotos else {
-                        (oldState.photosState as? AppUiState.Success)?.data.orEmpty() + newPhotos
-                    }
-                    oldState.copy(
+                _state.update { currentState ->
+                    val oldList =
+                        if (isRefresh) emptyList()
+                        else (currentState.photosState as? AppUiState.Success)?.data ?: emptyList()
+
+                    val combinedList = (oldList + newPhotos).distinctBy { it.displayId }
+
+                    currentState.copy(
                         photosState = AppUiState.Success(combinedList),
                         photosPage = page,
-                        isPhotosLoadingMore = false,
+                        isRefreshing = false,
+                        photosAppendError = null,
                         isPhotosEndOfList = newPhotos.isEmpty()
                     )
                 }
+
+                if (page > 1) internalLoading = false
             },
             onError = { msg ->
                 logger.e { "Error loading topic photos: $msg" }
-                if (isRefresh) _state.update { it.copy(photosState = AppUiState.Error(msg)) }
-                else _state.update { it.copy(isPhotosLoadingMore = false) }
+                _state.update { currentState ->
+                    val oldList = (currentState.photosState as? AppUiState.Success)?.data
+                    if (!oldList.isNullOrEmpty()) {
+                        currentState.copy(
+                            photosAppendError = msg,
+                            isRefreshing = false
+                        )
+                    } else {
+                        currentState.copy(
+                            photosState = AppUiState.Error(msg),
+                            photosAppendError = null,
+                            isRefreshing = false
+                        )
+                    }
+                }
+
+                if (page > 1) internalLoading = false
             }
         )
     }

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/UserContract.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/UserContract.kt
@@ -33,14 +33,15 @@ enum class UserTab(val title: String) {
 data class UserDetailUiState(
     val currentTab: UserTab = UserTab.Photos,
 
-    val loadingMoreStatus: Map<UserTab, Boolean> = emptyMap(),
+    val refreshingStatus: Map<UserTab, Boolean> = emptyMap(),
     val endOfListStatus: Map<UserTab, Boolean> = emptyMap(),
     val pages: Map<UserTab, Int> = emptyMap(),
+    val appendError: Map<UserTab, String> = emptyMap(),
 
     val infoState: AppUiState<UserProfile> = AppUiState.Idle,
     val photosState: AppUiState<List<GalleryDisplayable>> = AppUiState.Idle,
     val collectionsState: AppUiState<List<GalleryDisplayable>> = AppUiState.Idle,
-    val likesState: AppUiState<List<GalleryDisplayable>> = AppUiState.Idle
+    val likesState: AppUiState<List<GalleryDisplayable>> = AppUiState.Idle,
 )
 
 // UI Intents

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/UserScreen.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/UserScreen.kt
@@ -33,6 +33,7 @@ import io.lackstudio.omnifeed.ui.state.AppUiState
 import io.lackstudio.omnihub.compose.ui.components.ExpandableText
 import io.lackstudio.omnihub.compose.ui.navigation.Feature
 import io.lackstudio.omnihub.compose.ui.navigation.XrNavEvent
+import io.lackstudio.omnihub.compose.ui.navigation.rememberGalleryNavigator
 import io.lackstudio.omnihub.compose.utils.LocalXrNavigation
 import io.lackstudio.omnihub.compose.utils.UnsplashLinks
 import io.lackstudio.omnihub.compose.utils.logging.rememberLogger
@@ -56,6 +57,8 @@ fun UserDetailScreen(
     animatedVisibilityScope: AnimatedVisibilityScope
 ) {
     val logger = rememberLogger("UserDetailScreen")
+    val navigator = rememberGalleryNavigator(onNavigateToFeature)
+
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     LaunchedEffect(username) {
@@ -78,6 +81,8 @@ fun UserDetailScreen(
         Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
             UserDetailContent(
                 state = state,
+                onItemClick = navigator::navigateToPhoto,
+                onUserClick = navigator::navigateToUser,
                 onEvent = { event ->
                     logger.d { "UserDetailScreen: onEvent: $event" }
                     viewModel.handleIntent(event)
@@ -94,6 +99,8 @@ fun UserDetailScreen(
 @Composable
 fun UserDetailContent(
     state: UserDetailUiState,
+    onItemClick: (GalleryDisplayable) -> Unit,
+    onUserClick: (String) -> Unit,
     onEvent: (UserDetailIntent) -> Unit,
     onNavigateToFeature: (Feature) -> Unit,
     sharedTransitionScope: SharedTransitionScope,
@@ -102,6 +109,7 @@ fun UserDetailContent(
     val tabs = UserTab.entries
     val pagerState = rememberPagerState(pageCount = { tabs.size })
     val coroutineScope = rememberCoroutineScope()
+    val xrNav = LocalXrNavigation.current
 
     LaunchedEffect(state.currentTab) {
         if (pagerState.currentPage != state.currentTab.ordinal) {
@@ -159,129 +167,67 @@ fun UserDetailContent(
         ) { pageIndex ->
             val tab = UserTab.getByIndex(pageIndex)
             val isEndOfList = state.endOfListStatus[tab] ?: false
+            val isRefreshing = state.refreshingStatus[tab] ?: false
+            val currentError = state.appendError[tab]?.takeIf { it.isNotBlank() }
 
             when (tab) {
                 UserTab.Photos -> {
-                    UserPhotosSection(
+                    GalleryPagedSection(
                         state = state.photosState,
+                        isRefreshing = isRefreshing,
+                        onRefresh = { onEvent(UserDetailIntent.Refresh) },
                         isEndOfList = isEndOfList,
+                        appendError = currentError,
+                        emptyMessage = "No photos uploaded",
                         onLoadMore = { onEvent(UserDetailIntent.LoadMore) },
-                        onNavigateToFeature = onNavigateToFeature,
                         sharedTransitionScope = sharedTransitionScope,
                         animatedVisibilityScope = animatedVisibilityScope,
+                        onItemClick = onItemClick,
+                        onUserClick = onUserClick
                     )
                 }
                 UserTab.Collections -> {
-                    UserCollectionsSection(
+                    GalleryPagedSection(
                         state = state.collectionsState,
+                        isRefreshing = isRefreshing,
+                        onRefresh = { onEvent(UserDetailIntent.Refresh) },
                         isEndOfList = isEndOfList,
+                        appendError = currentError,
+                        emptyMessage = "No collections found",
                         onLoadMore = { onEvent(UserDetailIntent.LoadMore) },
-                        onNavigateToFeature = onNavigateToFeature
+                        onItemClick = { item ->
+                            onNavigateToFeature(Feature.Collection(item.displayId, item.displayTitle))
+                        },
+                        onUserClick = { username ->
+                            if (xrNav != null) xrNav(XrNavEvent.NavigateToUser(username))
+                            else onNavigateToFeature(Feature.User(username))
+                        }
                     )
                 }
 
                 UserTab.Likes -> {
-                    UserPhotosSection(
+                    GalleryPagedSection(
                         state = state.likesState,
+                        isRefreshing = isRefreshing,
+                        onRefresh = { onEvent(UserDetailIntent.Refresh) },
                         isEndOfList = isEndOfList,
+                        appendError = currentError,
+                        emptyMessage = "No liked photos",
                         onLoadMore = { onEvent(UserDetailIntent.LoadMore) },
-                        onNavigateToFeature = onNavigateToFeature,
                         sharedTransitionScope = sharedTransitionScope,
                         animatedVisibilityScope = animatedVisibilityScope,
+                        onItemClick = { item ->
+                            val ratio = item.displayWidth / item.displayHeight.toFloat()
+                            val url = item.displayImageUrl ?: ""
+                            if (xrNav != null) xrNav(XrNavEvent.NavigateToPhoto(item.displayId, url, ratio))
+                            else onNavigateToFeature(Feature.Photo(item.displayId, url))
+                        },
+                        onUserClick = { username ->
+                            if (xrNav != null) xrNav(XrNavEvent.NavigateToUser(username))
+                            else onNavigateToFeature(Feature.User(username))
+                        }
                     )
                 }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalSharedTransitionApi::class)
-@Composable
-fun UserPhotosSection(
-    state: AppUiState<List<GalleryDisplayable>>,
-    isEndOfList: Boolean,
-    onLoadMore: () -> Unit,
-    onNavigateToFeature: (Feature) -> Unit,
-    sharedTransitionScope: SharedTransitionScope,
-    animatedVisibilityScope: AnimatedVisibilityScope,
-) {
-    val xrNav = LocalXrNavigation.current
-
-    when (state) {
-        is AppUiState.Loading, AppUiState.Idle -> {
-            Box(modifier = Modifier.fillMaxSize().height(200.dp), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
-        }
-        is AppUiState.Error -> {
-            Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
-                Text("Failed to load photos", color = MaterialTheme.colorScheme.error)
-            }
-        }
-        is AppUiState.Success -> {
-            val photos = state.data
-            if (photos.isEmpty()) {
-                Box(modifier = Modifier.fillMaxSize().height(100.dp), contentAlignment = Alignment.Center) {
-                    Text("No photos uploaded", color = Color.Gray)
-                }
-            } else {
-                PhotoList(
-                    photos = photos,
-                    sharedTransitionScope = sharedTransitionScope,
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    isEndOfList = isEndOfList,
-                    onLoadMore = onLoadMore,
-                    onPhotoClick = { id, url, ratio ->
-                        if (xrNav != null) {
-                            xrNav(XrNavEvent.NavigateToPhoto(id, url, ratio))
-                        } else {
-                            onNavigateToFeature(Feature.Photo(id, url))
-                        }
-
-                    },
-                    onUserClick = { username ->
-                        onNavigateToFeature(Feature.User(username))
-                    }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun UserCollectionsSection(
-    state: AppUiState<List<GalleryDisplayable>>,
-    isEndOfList: Boolean,
-    onLoadMore: () -> Unit,
-    onNavigateToFeature: (Feature) -> Unit
-) {
-    when (state) {
-        is AppUiState.Loading, AppUiState.Idle -> {
-            Box(modifier = Modifier.fillMaxSize().height(200.dp), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
-        }
-        is AppUiState.Error -> {
-            Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
-                Text("Failed to load collections", color = MaterialTheme.colorScheme.error)
-            }
-        }
-        is AppUiState.Success -> {
-            val collections = state.data
-            if (collections.isEmpty()) {
-                Box(modifier = Modifier.fillMaxSize().height(100.dp), contentAlignment = Alignment.Center) {
-                    Text("No collections found", color = Color.Gray)
-                }
-            } else {
-                CollectionList(
-                    collections = collections,
-                    isEndOfList = isEndOfList,
-                    onLoadMore = onLoadMore,
-                    onCollectionClick = { id, title ->
-                        onNavigateToFeature(Feature.Collection(id, title))
-                    },
-                    onUserClick = {}
-                )
             }
         }
     }
@@ -520,6 +466,8 @@ private fun UserDetailContentPreview() {
                             UserTab.Likes to false
                         )
                     ),
+                    onItemClick = {},
+                    onUserClick = {},
                     onEvent = {},
                     onNavigateToFeature = {},
                     sharedTransitionScope = this@SharedTransitionLayout,

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/UserViewModel.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/gallery/UserViewModel.kt
@@ -61,7 +61,13 @@ class UserViewModel(
                 currentUsername?.let { loadNextPage(it) }
             }
             is UserDetailIntent.Refresh -> {
-                logger.d { "handleIntent: Refresh" }
+                _state.update { currentState ->
+                    logger.d { "handleIntent: Refresh" }
+                    currentState.copy(
+                        refreshingStatus = currentState.refreshingStatus +
+                                (currentState.currentTab to true)
+                    )
+                }
                 currentUsername?.let { username ->
                     // Reload user information
                     loadUserInfo(username)
@@ -103,17 +109,21 @@ class UserViewModel(
 
     // Determine if next page loading is needed
     private fun loadNextPage(username: String) {
-        val currentTab = _state.value.currentTab
+        val currentState = _state.value
+        val currentTab = currentState.currentTab
 
         // Check lock (is it currently loading)
-        if (internalLoadingMap.getValue(currentTab)) return
+        if (internalLoadingMap[currentTab] == true) return
+
+        val isRefreshing = currentState.refreshingStatus[currentTab] ?: false
+        if (isRefreshing) return
 
         // Check if end of list reached
-        val isEndOfList = _state.value.endOfListStatus[currentTab] ?: false
+        val isEndOfList = currentState.endOfListStatus[currentTab] ?: false
         if (isEndOfList) return
 
         // Calculate next page
-        val currentPage = _state.value.pages[currentTab] ?: 1
+        val currentPage = currentState.pages[currentTab] ?: 1
         val nextPage = currentPage + 1
 
         // Execute loading
@@ -136,28 +146,30 @@ class UserViewModel(
     private fun <T, R> fetchUserCategory(
         tab: UserTab,
         targetPage: Int,
-        currentSubState: AppUiState<List<R>>,
+//        currentSubState: AppUiState<List<R>>,
         getOldList: (UserDetailUiState) -> List<R>?,
         useCase: suspend () -> UseCaseResult<List<T>>,
         mapper: (List<T>) -> List<R>,
+        distinctBy: (R) -> Any,
         stateReducer: (UserDetailUiState, AppUiState<List<R>>) -> UserDetailUiState
     ) {
         // Set internal lock
-        internalLoadingMap[tab] = true
+        if (targetPage > 1 && internalLoadingMap.getValue(tab)) return
+        if (targetPage > 1) internalLoadingMap[tab] = true
 
         handleUseCaseCall(
             name = "User $tab",
             useCase = useCase,
             onLoading = {
-                // Logic: Show full-page loading only if it's page 1 and there is no data
-                // If it's page 1 but has data (representing Pull-to-Refresh), do not show full-page loading
-                // If it's Load More (Page > 1), show footer loading indicator
-                val hasOldData = targetPage > 1 || (currentSubState is AppUiState.Success && currentSubState.data.isNotEmpty())
+                _state.update { currentState ->
+                    val oldList = getOldList(currentState)
+                    val hasOldData = !oldList.isNullOrEmpty()
 
-                if (!hasOldData) {
-                    _state.update { stateReducer(it, AppUiState.Loading) }
-                } else if (targetPage > 1) {
-                    updateLoadingMap(tab, true)
+                    if (!hasOldData) {
+                        stateReducer(currentState, AppUiState.Loading)
+                    } else {
+                        currentState
+                    }
                 }
             },
             onSuccess = { resultData ->
@@ -165,37 +177,54 @@ class UserViewModel(
                 val isEndOfList = newItems.isEmpty()
 
                 _state.update { currentState ->
-                    // Get old data (if Page 1, clear it, representing Refresh)
                     val oldList = if (targetPage > 1) {
                         getOldList(currentState).orEmpty()
                     } else {
                         emptyList()
                     }
 
-                    // Merge data
-                    val combinedList = oldList + newItems
+                    val combinedList = (oldList + newItems).distinctBy(distinctBy)
 
-                    // Update specific data fields
-                    val intermediateState = stateReducer(currentState, AppUiState.Success(combinedList))
+                    val newPagesMap = currentState.pages + (tab to targetPage)
+                    val newEndOfListMap = currentState.endOfListStatus + (tab to isEndOfList)
+                    val newErrorMap = currentState.appendError - tab
+                    val newRefreshMap = currentState.refreshingStatus + (tab to false)
 
-                    // Update paging and status Map
-                    intermediateState.copy(
-                        pages = intermediateState.pages + (tab to targetPage),
-                        endOfListStatus = intermediateState.endOfListStatus + (tab to isEndOfList),
-                        loadingMoreStatus = intermediateState.loadingMoreStatus + (tab to false)
-                    )
+                    stateReducer(currentState, AppUiState.Success(combinedList))
+                        .copy(
+                            pages = newPagesMap,
+                            endOfListStatus = newEndOfListMap,
+                            appendError = newErrorMap,
+                            refreshingStatus = newRefreshMap
+                        )
                 }
                 // Unlock
                 internalLoadingMap[tab] = false
             },
-            onError = { msg ->
-                logger.e { "Error fetching user category ($tab): $msg" }
+            onError = { errorMessage ->
+                logger.e { "Error fetching user category ($tab): $errorMessage" }
                 // If page 1 fails, show full-page error
                 // If Load More fails, only hide footer loading indicator
-                if (targetPage == 1) {
-                    _state.update { stateReducer(it, AppUiState.Error(msg)) }
-                } else {
-                    updateLoadingMap(tab, false)
+                _state.update { currentState ->
+                    val oldList = getOldList(currentState)
+                    val newRefreshMap = currentState.refreshingStatus + (tab to false)
+
+                    if (!oldList.isNullOrEmpty()) {
+                        val newErrorMap = currentState.appendError + (tab to errorMessage)
+                        stateReducer(currentState, AppUiState.Success(oldList))
+                            .copy(
+                                refreshingStatus = newRefreshMap,
+                                appendError = newErrorMap
+                            )
+                    } else {
+                        // Only show a full-screen error when there is absolutely no data (e.g., no internet on the first app launch).
+                        val newErrorMap = currentState.appendError - tab
+                        stateReducer(currentState, AppUiState.Error(errorMessage))
+                            .copy(
+                                refreshingStatus = newRefreshMap,
+                                appendError = newErrorMap
+                            )
+                    }
                 }
                 internalLoadingMap[tab] = false
             }
@@ -208,7 +237,6 @@ class UserViewModel(
         fetchUserCategory(
             tab = UserTab.Photos,
             targetPage = page,
-            currentSubState = _state.value.photosState,
             // Lambda for getting old data
             getOldList = { state -> (state.photosState as? AppUiState.Success)?.data },
             // UseCase
@@ -230,6 +258,7 @@ class UserViewModel(
                     )
                 }
             },
+            distinctBy = {it.displayId},
             // Reducer
             stateReducer = { state, newState -> state.copy(photosState = newState) }
         )
@@ -241,7 +270,6 @@ class UserViewModel(
         fetchUserCategory(
             tab = UserTab.Collections,
             targetPage = page,
-            currentSubState = _state.value.collectionsState,
             // Get old data
             getOldList = { state -> (state.collectionsState as? AppUiState.Success)?.data },
             // UseCase
@@ -267,6 +295,7 @@ class UserViewModel(
                     )
                 }
             },
+            distinctBy = {it.displayId},
             // Reducer
             stateReducer = { state, newState -> state.copy(collectionsState = newState) }
         )
@@ -278,7 +307,6 @@ class UserViewModel(
         fetchUserCategory(
             tab = UserTab.Likes,
             targetPage = page,
-            currentSubState = _state.value.likesState,
             // Get old data
             getOldList = { state -> (state.likesState as? AppUiState.Success)?.data },
             useCase = { getUserLikedPhotosUseCase(params) },
@@ -300,15 +328,9 @@ class UserViewModel(
                     )
                 }
             },
+            distinctBy = {it.displayId},
             // Reducer: Update likesState
             stateReducer = { state, newState -> state.copy(likesState = newState) }
         )
-    }
-
-    // Helper function: Update Loading Map (for Load More footer loading)
-    private fun updateLoadingMap(tab: UserTab, isLoading: Boolean) {
-        _state.update {
-            it.copy(loadingMoreStatus = it.loadingMoreStatus + (tab to isLoading))
-        }
     }
 }

--- a/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/navigation/GalleryNavigator.kt
+++ b/compose/src/commonMain/kotlin/io/lackstudio/omnihub/compose/ui/navigation/GalleryNavigator.kt
@@ -1,0 +1,43 @@
+package io.lackstudio.omnihub.compose.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import io.lackstudio.omnihub.compose.ui.gallery.GalleryDisplayable
+import io.lackstudio.omnihub.compose.utils.LocalXrNavigation
+
+class GalleryNavigator(
+    private val xrNav: ((XrNavEvent) -> Unit)?,
+    private val onNavigateToFeature: (Feature) -> Unit
+) {
+    // Unified logic for handling photo clicks (automatically calculates ratio)
+    fun navigateToPhoto(item: GalleryDisplayable) {
+        val ratio = if (item.displayHeight > 0) {
+            item.displayWidth / item.displayHeight.toFloat()
+        } else 1f
+        val url = item.displayImageUrl ?: ""
+
+        if (xrNav != null) {
+            xrNav(XrNavEvent.NavigateToPhoto(item.displayId, url, ratio))
+        } else {
+            onNavigateToFeature(Feature.Photo(item.displayId, url))
+        }
+    }
+
+    // Unified logic for handling user clicks
+    fun navigateToUser(username: String) {
+        if (xrNav != null) {
+            xrNav(XrNavEvent.NavigateToUser(username))
+        } else {
+            onNavigateToFeature(Feature.User(username))
+        }
+    }
+}
+
+// Create a convenient Composable function to easily obtain the Navigator in every screen
+@Composable
+fun rememberGalleryNavigator(onNavigateToFeature: (Feature) -> Unit): GalleryNavigator {
+    val xrNav = LocalXrNavigation.current
+    return remember(xrNav, onNavigateToFeature) {
+        GalleryNavigator(xrNav, onNavigateToFeature)
+    }
+}


### PR DESCRIPTION
### Related Issues

- Closes #45 

### Type of Change

Please check the main type of change this PR introduces. If there are multiple, please select the most significant one.

- [ ] **feat:** New feature
- [x] **fix:** Bug fix
- [x] **refactor:** Code refactoring
- [ ] **docs:** Documentation update
- [ ] **chore:** Chore (e.g., updating dependencies, build tooling)
- [ ] **style:** Style changes (e.g., formatting, no code logic changes)
- [ ] **test:** Adding or modifying tests
- [ ] **other:** Other: [Please briefly describe]

### Description

Refactored `GalleryScreen`, `CollectionScreen`, `TopicScreen`, and `UserScreen` to use standardized paging components and centralized navigation logic.

- Added `GalleryNavigator` and `rememberGalleryNavigator` to provide a unified way to handle photo and user navigation across different screens, supporting both standard and XR-based navigation.
- Introduced `StatefulListContent`, `GalleryPagedSection`, and `TopicPagedSection` to encapsulate common UI patterns for loading, error, and empty states.
- Implemented `GalleryDisplayableList` to handle staggered grid displays with built-in "Scroll to Top" FAB and pagination logic.
- Updated `pagingItems`, `pagingGridItems`, and `pagingStaggeredGridItems` extensions to support displaying append-specific error messages in the list footer.
- Enhanced `GalleryViewModel`, `TopicViewModel`, `CollectionViewModel`, and `UserViewModel` with improved state management for refreshing, pagination, and deduplication of items using `distinctBy`.
- Standardized UI contracts to include `refreshingStatus`, `endOfListStatus`, and `appendError` maps across different feature modules.
- Integrated `SafePullToRefreshBox` across detail screens to ensure consistent pull-to-refresh behavior.

### How to test it?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Navigate to the Gallery, Collection, Topic, or User screens and scroll down to trigger pagination.
- Simulate a network error during pagination (e.g., disable Wi-Fi) to verify the existing list is preserved and the error message appears at the bottom.
- Scroll past the first two items to confirm the "Scroll to Top" FAB appears and functions correctly when clicked.
- Perform a pull-to-refresh to ensure data reloads smoothly without UI flickering.

**Tested Platforms:**
- [x] Android
- [x] iOS
- [x] Desktop (JVM)
- [x] Web (Wasm/JS)
- [ ] Shared Logic (Unit Tests)

**Test Details:**
- [ ] **Unit tests:** Did you write new tests to verify the smallest units of code?
- [ ] **Integration tests:** Did you test how different parts of the system work together?
- [x] **Manual testing:** Please describe the steps a reviewer can follow to manually test your changes.

### Review Checklist

Before submitting this PR, please confirm the following:

- [x] My code follows the project's coding style guidelines.
- [x] I have added sufficient comments to my code, especially in complex areas.
- [x] I have updated the relevant documentation.
- [x] My changes don't introduce new bugs.
- [x] I have tested my code locally.